### PR TITLE
fix(docker): support --transport http via ENTRYPOINT + http feature (#20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,14 @@ FROM rust:1.86-slim as builder
 WORKDIR /usr/src/app
 COPY . .
 
+# Build with the `http` feature so the published image supports both
+# stdio (default) and streamable-HTTP transports. Without this flag the
+# binary panics at runtime with "HTTP transport is not enabled. Rebuild
+# with the 'http' feature" the moment a user passes `--transport http`.
+# See https://github.com/gbrigandi/mcp-server-wazuh/issues/20.
 RUN apt-get update && \
     apt-get install -y pkg-config libssl-dev build-essential perl make && \
-    cargo build --release
+    cargo build --release --features http
 
 FROM debian:bookworm-slim
 
@@ -23,4 +28,10 @@ USER wazuh
 
 EXPOSE 8000
 
-CMD ["./mcp-server-wazuh"]
+# Use ENTRYPOINT (rather than CMD) so flags passed via
+# `docker run <image> --transport http ...` are appended to the binary
+# invocation instead of replacing it. The previous `CMD ["./mcp-server-wazuh"]`
+# caused `docker run … --transport http` to fail with
+# `exec: "--transport": executable file not found in $PATH`. Issue #20.
+ENTRYPOINT ["./mcp-server-wazuh"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ For enhanced threat intelligence and incident response capabilities, the Wazuh M
     docker pull ghcr.io/gbrigandi/mcp-server-wazuh:latest
     ```
 
+2.  **Run with the streamable-HTTP transport (so other hosts on your
+    network can connect):**
+    ```bash
+    docker run -d --name mcp-server-wazuh \
+      -p 8000:8000 \
+      --env-file /path/to/your/.env \
+      ghcr.io/gbrigandi/mcp-server-wazuh:latest \
+      --transport http --host 0.0.0.0 --port 8000
+    ```
+    `--host 0.0.0.0` is required so the listener binds inside the
+    container and is reachable through the published port; the binary
+    defaults to `127.0.0.1`, which only binds inside the container's
+    network namespace and is not reachable from outside.
+
+    For the stdio transport (typical Claude Desktop / MCP client setup
+    where the client launches the container itself), see the JSON
+    config block further down — the client passes `-i` and consumes
+    stdio directly, no `--transport` flag needed.
+
 ### Option 3: Build from Source
 
 1.  **Prerequisites:**


### PR DESCRIPTION
Closes #20.

Two stacked Dockerfile bugs were surfacing as the same crash for the user.

**1) \`CMD\` replaces, doesn't append.** The previous \`CMD [\"./mcp-server-wazuh\"]\` is replaced wholesale by anything passed after the image name on \`docker run\`. So:

\`\`\`
docker run -d --name mcp-server-wazuh <image> --transport http
\`\`\`

resulted in docker trying to run \`--transport\` as the entrypoint itself — hence \`exec: \"--transport\": executable file not found in $PATH\`.

Switching to \`ENTRYPOINT [\"./mcp-server-wazuh\"]\` with an empty \`CMD []\` keeps the binary as the program and lets user args append to its argv. Verified:

\`\`\`
docker run --rm <image> --help                          → prints clap help
docker run --rm <image> --transport http \\
                        --host 0.0.0.0 --port 8000      → binds /mcp
\`\`\`

**2) The image was built without the \`http\` feature.** Even with the entrypoint fix, \`--transport http\` would still bail at runtime with \`HTTP transport is not enabled. Rebuild with the 'http' feature\` because the published binary was built via \`cargo build --release\` (default features only). Build step now passes \`--features http\` so both transports are compiled into the same image — the stdio default keeps working unchanged.

**README**: Docker section now shows the http-transport invocation, including the \`--host 0.0.0.0\` requirement. The binary defaults to \`127.0.0.1\`, which only binds inside the container's network namespace and isn't reachable through \`-p 8000:8000\` — a separate gotcha the user would hit immediately after the fix above. Calling that out inline so the next person doesn't get tripped up.

## What's not addressed

The user's separate "stdio crash on \`docker run -d\`" symptom in the second comment is not a bug in this server — \`-d\` (detach) means there's no actual stdio attached, so the MCP stdio handshake fails as expected. The right answer is "use \`--transport http\` for daemon-style deployments", which the README now demonstrates. If you'd rather have the binary detect this and emit a clearer error than \`ConnectionClosed(\"initialized request\")\`, happy to do that as a follow-up — kept this PR focused on the docker dispatch problem since that's the harder-to-debug part.

## Test plan

- [x] \`docker build -t test .\` clean
- [x] \`docker run --rm test --help\` prints help (was: \"executable file not found\")
- [x] \`docker run --rm test --transport http --host 0.0.0.0 --port 8000\` binds and serves on \`/mcp\`
- [x] Existing stdio default behaviour unchanged (\`docker run -i test\` still works for Claude Desktop / MCP-client launching)